### PR TITLE
Use non-deprecated PodDisruptionBudget version.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+layout go

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ run: generate fmt vet manifests ## Run against the configured Kubernetes cluster
 docker-build: go-releaser ## Build the docker image.
 	GOOS=linux GOARCH=amd64 DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
 	  $(GO_RELEASER) build --skip-validate --rm-dist --single-target
-	DOCKER_BUILDKIT=1 docker build . -t ${CONTROLLER_IMG} --build-arg VERSION=${VERSION}
+	DOCKER_BUILDKIT=1 docker build . -t ${CONTROLLER_IMG} --build-arg VERSION=${VERSION} --build-arg TARGETARCH=amd64 --platform linux/amd64
 
 docker-push: ## Push the docker image.
 	docker push ${CONTROLLER_IMG}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -29,7 +29,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -755,7 +755,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapConfigMapsToClusters(ctx)),

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -184,12 +184,12 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceExistsWithDefaultClient(
 				pdbPrimaryName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 			expectResourceExistsWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 
@@ -209,7 +209,7 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceDoesntExistWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 
@@ -226,12 +226,12 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceDoesntExistWithDefaultClient(
 				pdbPrimaryName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 			expectResourceDoesntExistWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 	})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1662096612,
+        "narHash": "sha256-R+Q8l5JuyJryRPdiIaYpO5O3A55rT+/pItBrKcy7LM4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "21de2b973f9fee595a7a1ac4693efff791245c34",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.simpleFlake {
+      inherit self nixpkgs;
+      name = "cloudnative-pg";
+      shell = { pkgs ? nixpkgs }:
+        pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            pkgs.gotools
+            pkgs.gopls
+            pkgs.go-outline
+            pkgs.gocode
+            pkgs.gopkgs
+            pkgs.gocode-gomod
+            pkgs.godef
+            pkgs.golint
+          ];
+        };
+    };
+}

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -17,7 +17,7 @@ limitations under the License.
 package specs
 
 import (
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -26,7 +26,7 @@ import (
 
 // BuildReplicasPodDisruptionBudget creates a pod disruption budget telling
 // K8s to avoid removing more than one replica at a time
-func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.PodDisruptionBudget {
+func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisruptionBudget {
 	// We should ensure that in a cluster of n instances,
 	// with n-1 replicas, at least n-2 are always available
 	if cluster == nil || cluster.Spec.Instances < 3 {
@@ -35,12 +35,12 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.Pod
 	minAvailableReplicas := cluster.Spec.Instances - 2
 	allReplicasButOne := intstr.FromInt(minAvailableReplicas)
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
 			Namespace: cluster.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					ClusterLabelName:     cluster.Name,
@@ -54,18 +54,18 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.Pod
 
 // BuildPrimaryPodDisruptionBudget creates a pod disruption budget, telling
 // K8s to avoid removing more than one primary instance at a time
-func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.PodDisruptionBudget {
+func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisruptionBudget {
 	if cluster == nil {
 		return nil
 	}
 	one := intstr.FromInt(1)
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name + apiv1.PrimaryPodDisruptionBudgetSuffix,
 			Namespace: cluster.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					ClusterLabelName:     cluster.Name,


### PR DESCRIPTION
Addresses https://github.com/cloudnative-pg/cloudnative-pg/issues/413 via option 2: drop support for Kubernetes 1.19 and 1.20 by replacing `betav1policyv1/PodDisruptionBudget` with `policyv1/PodDisruptionBudget`.